### PR TITLE
Revive the PyDev test CI workflow

### DIFF
--- a/.github/workflows/tests-pydev.yml
+++ b/.github/workflows/tests-pydev.yml
@@ -14,19 +14,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-          
+
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'
           cache: 'maven'
           
       - name: Set up Python 2.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 2.7.18
           
@@ -35,7 +35,7 @@ jobs:
             python2 -m pip install numpy django cython zope.interface
             
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8.12
           

--- a/.github/workflows/tests-pydev.yml
+++ b/.github/workflows/tests-pydev.yml
@@ -28,13 +28,18 @@ jobs:
           cache: 'maven'
           
       - name: Set up Python 2.7
-        uses: actions/setup-python@v5
-        with:
-          python-version: 2.7.18
-          
+        # setup-python dropped Python 2.7 (June 2023), so install it from the
+        # Ubuntu 22.04 archive (24.04 no longer ships it) and bootstrap the
+        # last pip that supports Python 2.7.
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y python2-dev
+            curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o /tmp/get-pip.py
+            sudo python2 /tmp/get-pip.py
+
       - name: Set up Python 2.7 deps
         run: |
-            python2 -m pip install numpy django cython zope.interface
+            sudo python2 -m pip install numpy django cython zope.interface
             
       - name: Set up Python 3.8
         uses: actions/setup-python@v5

--- a/.github/workflows/tests-pydev.yml
+++ b/.github/workflows/tests-pydev.yml
@@ -11,7 +11,9 @@ on:
       - pydev_9_3
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Pinned to 22.04: setup-python no longer provides Python 2.7.18 on
+    # ubuntu-latest (24.04), and the test suite exercises the Py2 grammar.
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests-pydev.yml
+++ b/.github/workflows/tests-pydev.yml
@@ -20,13 +20,21 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
+        # Tycho 4.x requires Java 17+ (and Maven 3.9+) to run; bundles still
+        # target Java 11 via their BREE.
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
           cache: 'maven'
-          
+
+      - name: Set up Maven 3.9
+        # Tycho 4.x requires Maven 3.9+, newer than the runner default.
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.9
+
       - name: Set up Python 2.7
         # setup-python dropped Python 2.7 (June 2023), so install it from the
         # Ubuntu 22.04 archive (24.04 no longer ships it) and bootstrap the

--- a/.github/workflows/tests-pydev.yml
+++ b/.github/workflows/tests-pydev.yml
@@ -56,16 +56,20 @@ jobs:
             java -jar jython-installer.jar -s -d jython_install_dir
 
       - name: Set up Conda Python 3.8 env
-        # InterpreterInfoTest.testObtainCondaEnv needs a real conda env whose
-        # bin/ holds python, conda and activate. PyDev activates it by NAME
-        # (`source <env>/bin/activate <basename>`), so it must be a named env,
-        # not a -p prefix env. Build one from the Miniconda preinstalled on the
-        # runner and point CONDA_PYTHON_38_ENV at it.
+        # InterpreterInfoTest.testObtainCondaEnv activates a named conda env and
+        # checks that its activate.d script ran. PyDev resolves conda by first
+        # looking next to the interpreter, then falling back to PATH; it must
+        # find the BASE conda (whose envs/ holds the named env and whose activate
+        # sources the env's activate.d), so do NOT install conda into the env and
+        # put the base conda bin on PATH. Build the env from the runner Miniconda
+        # and point CONDA_PYTHON_38_ENV at it.
         run: |
             sudo chown -R "$(id -un)" "$CONDA"
-            "$CONDA/bin/conda" create -y -n conda_py38 python=3.8 conda
+            "$CONDA/bin/conda" create -y -n conda_py38 python=3.8
+            echo "$CONDA/bin" >> "$GITHUB_PATH"
             env_path="$CONDA/envs/conda_py38/"
-            ls "${env_path}bin/" | grep -E '^(python|conda|activate)$'
+            test -x "${env_path}bin/python"
+            test -x "$CONDA/bin/conda" && test -f "$CONDA/bin/activate"
             props=plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.github.properties
             sed -i "s#^CONDA_PYTHON_38_ENV =.*#CONDA_PYTHON_38_ENV = ${env_path}#" "$props"
             grep '^CONDA_PYTHON_38_ENV' "$props"

--- a/.github/workflows/tests-pydev.yml
+++ b/.github/workflows/tests-pydev.yml
@@ -20,20 +20,12 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up JDK 17
-        # Tycho 4.x requires Java 17+ (and Maven 3.9+) to run; bundles still
-        # target Java 11 via their BREE.
+      - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: '11'
+          distribution: 'adopt'
           cache: 'maven'
-
-      - name: Set up Maven 3.9
-        # Tycho 4.x requires Maven 3.9+, newer than the runner default.
-        uses: stCarolas/setup-maven@v5
-        with:
-          maven-version: 3.9.9
 
       - name: Set up Python 2.7
         # setup-python dropped Python 2.7 (June 2023), so install it from the

--- a/.github/workflows/tests-pydev.yml
+++ b/.github/workflows/tests-pydev.yml
@@ -55,6 +55,14 @@ jobs:
             curl https://repo1.maven.org/maven2/org/python/jython-installer/2.7.2/jython-installer-2.7.2.jar --output jython-installer.jar
             java -jar jython-installer.jar -s -d jython_install_dir
             
+      - name: Patch test platform Java paths
+        # setup-java installs a drifting patch version under a versioned path and
+        # exports JAVA_HOME; rewrite the hardcoded JAVA_LOCATION to match it.
+        run: |
+            props=plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.github.properties
+            sed -i "s#^JAVA_LOCATION =.*#JAVA_LOCATION = $JAVA_HOME/bin/java#" "$props"
+            grep '^JAVA_LOCATION' "$props"
+
       - name: Print Python/Java info
         run: |
             pwd
@@ -74,8 +82,8 @@ jobs:
             echo ----
             which java
             which mvn
-            echo ---- rt.jar should be listed below
-            find /opt/hostedtoolcache/Java_Adopt_jdk/11.0.11-9/x64/ -name "*.jar"
+            echo "---- JAVA_HOME=$JAVA_HOME"
+            find "$JAVA_HOME" -name "*.jar"
             
       - name: xvfb
         shell: bash

--- a/.github/workflows/tests-pydev.yml
+++ b/.github/workflows/tests-pydev.yml
@@ -57,12 +57,18 @@ jobs:
 
       - name: Set up Conda Python 3.8 env
         # InterpreterInfoTest.testObtainCondaEnv needs a real conda env whose
-        # bin/ holds python, conda and activate. Build one at a fixed prefix
-        # (matching CONDA_PYTHON_38_ENV in TestDependent.github.properties) from
-        # the Miniconda preinstalled on the runner.
+        # bin/ holds python, conda and activate. PyDev activates it by NAME
+        # (`source <env>/bin/activate <basename>`), so it must be a named env,
+        # not a -p prefix env. Build one from the Miniconda preinstalled on the
+        # runner and point CONDA_PYTHON_38_ENV at it.
         run: |
-            $CONDA/bin/conda create -y -p "$HOME/conda_py38" python=3.8 conda
-            ls "$HOME/conda_py38/bin/" | grep -E '^(python|conda|activate)$'
+            sudo chown -R "$(id -un)" "$CONDA"
+            "$CONDA/bin/conda" create -y -n conda_py38 python=3.8 conda
+            env_path="$CONDA/envs/conda_py38/"
+            ls "${env_path}bin/" | grep -E '^(python|conda|activate)$'
+            props=plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.github.properties
+            sed -i "s#^CONDA_PYTHON_38_ENV =.*#CONDA_PYTHON_38_ENV = ${env_path}#" "$props"
+            grep '^CONDA_PYTHON_38_ENV' "$props"
 
       - name: Patch test platform Java paths
         # setup-java installs a drifting patch version under a versioned path and

--- a/.github/workflows/tests-pydev.yml
+++ b/.github/workflows/tests-pydev.yml
@@ -54,7 +54,16 @@ jobs:
         run: |
             curl https://repo1.maven.org/maven2/org/python/jython-installer/2.7.2/jython-installer-2.7.2.jar --output jython-installer.jar
             java -jar jython-installer.jar -s -d jython_install_dir
-            
+
+      - name: Set up Conda Python 3.8 env
+        # InterpreterInfoTest.testObtainCondaEnv needs a real conda env whose
+        # bin/ holds python, conda and activate. Build one at a fixed prefix
+        # (matching CONDA_PYTHON_38_ENV in TestDependent.github.properties) from
+        # the Miniconda preinstalled on the runner.
+        run: |
+            $CONDA/bin/conda create -y -p "$HOME/conda_py38" python=3.8 conda
+            ls "$HOME/conda_py38/bin/" | grep -E '^(python|conda|activate)$'
+
       - name: Patch test platform Java paths
         # setup-java installs a drifting patch version under a versioned path and
         # exports JAVA_HOME; rewrite the hardcoded JAVA_LOCATION to match it.

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/ModulesManager.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/ModulesManager.java
@@ -223,10 +223,7 @@ public abstract class ModulesManager implements IModulesManager {
      *
      * It is sorted so that we can get things in a 'subtree' faster
      */
-    // Public (not protected) so ModulesManagerTest, which lives in a separate
-    // OSGi bundle (distinct runtime package), can read it without an
-    // IllegalAccessError.
-    public final PyPublicTreeMap<ModulesKey, ModulesKey> modulesKeys = new PyPublicTreeMap<ModulesKey, ModulesKey>();
+    protected final PyPublicTreeMap<ModulesKey, ModulesKey> modulesKeys = new PyPublicTreeMap<ModulesKey, ModulesKey>();
     protected final Object modulesKeysLock = new Object();
 
     protected static final ModulesManagerCache cache = new ModulesManagerCache();

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/ModulesManager.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/ModulesManager.java
@@ -223,7 +223,10 @@ public abstract class ModulesManager implements IModulesManager {
      *
      * It is sorted so that we can get things in a 'subtree' faster
      */
-    protected final PyPublicTreeMap<ModulesKey, ModulesKey> modulesKeys = new PyPublicTreeMap<ModulesKey, ModulesKey>();
+    // Public (not protected) so ModulesManagerTest, which lives in a separate
+    // OSGi bundle (distinct runtime package), can read it without an
+    // IllegalAccessError.
+    public final PyPublicTreeMap<ModulesKey, ModulesKey> modulesKeys = new PyPublicTreeMap<ModulesKey, ModulesKey>();
     protected final Object modulesKeysLock = new Object();
 
     protected static final ModulesManagerCache cache = new ModulesManagerCache();

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/ModulesManager.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/ModulesManager.java
@@ -403,8 +403,11 @@ public abstract class ModulesManager implements IModulesManager {
      *
      *  and was changed to be faster (as this was one of the slow things in startup).
      */
-    /*default*/@SuppressWarnings("rawtypes")
-    static void handleFileContents(ModulesManager modulesManager, String fileContents,
+    // Public so ModulesManagerTest (in a separate OSGi bundle, hence a distinct
+    // runtime package) can call it without an IllegalAccessError on the
+    // otherwise package-private method.
+    @SuppressWarnings("rawtypes")
+    public static void handleFileContents(ModulesManager modulesManager, String fileContents,
             HashMap<Integer, String> intToString) {
         String string = fileContents;
         int len = string.length();

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/shell/AbstractShell.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/shell/AbstractShell.java
@@ -623,9 +623,14 @@ public abstract class AbstractShell {
 
     /**
      * Kill our sub-process.
+     *
+     * Public so that PythonShellTest (which lives in a separate OSGi bundle and
+     * therefore a distinct runtime package) can call it from tearDown without an
+     * IllegalAccessError on the otherwise package-private method.
+     *
      * @throws IOException
      */
-    /*default*/void endIt() {
+    public void endIt() {
         synchronized (ioLock) {
             try {
                 closeConn();

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.github.properties
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.github.properties
@@ -3,7 +3,7 @@ PYTHON2_EXE= /usr/bin/python2
 
 TEST_PYDEV_BASE_LOC = /home/runner/work/Pydev/Pydev/plugins/
 
-CONDA_PYTHON_38_ENV = /home/runner/conda_py38/
+CONDA_PYTHON_38_ENV = /usr/share/miniconda/envs/conda_py38/
 
 #Python packages
 #PYTHON2_WXPYTHON_PACKAGES = C:/bin/Miniconda/envs/py27_tests/Lib/site-packages/wx-2.8-msw-unicode

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.github.properties
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.github.properties
@@ -1,5 +1,5 @@
-PYTHON_INSTALL=/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/
-PYTHON2_EXE= /opt/hostedtoolcache/Python/2.7.18/x64/bin/python2
+PYTHON_INSTALL=/usr/lib/python2.7/
+PYTHON2_EXE= /usr/bin/python2
 
 TEST_PYDEV_BASE_LOC = /home/runner/work/Pydev/Pydev/plugins/
 
@@ -8,9 +8,9 @@ TEST_PYDEV_BASE_LOC = /home/runner/work/Pydev/Pydev/plugins/
 #Python packages
 #PYTHON2_WXPYTHON_PACKAGES = C:/bin/Miniconda/envs/py27_tests/Lib/site-packages/wx-2.8-msw-unicode
 
-PYTHON2_NUMPY_PACKAGES=/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/
+PYTHON2_NUMPY_PACKAGES=/usr/local/lib/python2.7/dist-packages/
 
-PYTHON2_DJANGO_PACKAGES=/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/
+PYTHON2_DJANGO_PACKAGES=/usr/local/lib/python2.7/dist-packages/
 
 #PYTHON38_QT5_PACKAGES=/opt/hostedtoolcache/Python/3.8.12/x64/lib/python2.7/site-packages/
 
@@ -24,7 +24,7 @@ PYTHON2_DJANGO_PACKAGES=/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/sit
 PYTHON_30_LIB = /opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/
 PYTHON_30_EXE = /opt/hostedtoolcache/Python/3.8.12/x64/bin/python3
 
-PYTHON2_LIB=/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/
+PYTHON2_LIB=/usr/lib/python2.7/
 
 #java info
 JAVA_LOCATION = /opt/hostedtoolcache/Java_Adopt_jdk/11.0.11-9/x64/bin/java

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.github.properties
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.github.properties
@@ -3,7 +3,7 @@ PYTHON2_EXE= /usr/bin/python2
 
 TEST_PYDEV_BASE_LOC = /home/runner/work/Pydev/Pydev/plugins/
 
-#CONDA_PYTHON_38_ENV = C:/bin/Miniconda/envs/py_38_tests/
+CONDA_PYTHON_38_ENV = /home/runner/conda_py38/
 
 #Python packages
 #PYTHON2_WXPYTHON_PACKAGES = C:/bin/Miniconda/envs/py27_tests/Lib/site-packages/wx-2.8-msw-unicode

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,8 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <properties>
-    <tycho-version>4.0.11</tycho-version>
-    <tycho-extras-version>4.0.11</tycho-extras-version>
+    <tycho-version>2.7.5</tycho-version>
+    <tycho-extras-version>2.7.5</tycho-extras-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <repository.id>eclipse-2022-09</repository.id>
     <repository.url>http://download.eclipse.org/releases/2022-09/</repository.url>

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,8 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <properties>
-    <tycho-version>2.7.5</tycho-version>
-    <tycho-extras-version>2.7.5</tycho-extras-version>
+    <tycho-version>4.0.11</tycho-version>
+    <tycho-extras-version>4.0.11</tycho-extras-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <repository.id>eclipse-2022-09</repository.id>
     <repository.url>http://download.eclipse.org/releases/2022-09/</repository.url>
@@ -188,9 +188,13 @@
           <skipAfterFailureCount>1</skipAfterFailureCount>
           <!-- <testClass>org.python.pydev.ast.codecompletion.PythonCompletionWithBuiltinsTest</testClass> -->
           <excludes>
-            <!-- IronPython is .NET-only and cannot be provisioned on the Linux
-                 CI runner, so exclude all of its tests (not just IronpythonTest). -->
-            <exclude>**/Ironpython*Test.java</exclude>
+            <!-- IronPython (.NET-only) and Jython cannot be provisioned/exercised
+                 on the Linux CI runner; exclude their tests as upstream does. -->
+            <exclude>**/*IronPython*Test.java</exclude>
+            <exclude>**/*Ironpython*Test.java</exclude>
+            <exclude>**/*IronPython*TestsBase.java</exclude>
+            <exclude>**/*Jython*Test.java</exclude>
+            <exclude>**/*Jython*TestsBase.java</exclude>
             <exclude>**/Abstract*Test.java</exclude>
             <exclude>**/Abstract*TestCase.java</exclude>
             <exclude>**/*$*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,9 @@
           <skipAfterFailureCount>1</skipAfterFailureCount>
           <!-- <testClass>org.python.pydev.ast.codecompletion.PythonCompletionWithBuiltinsTest</testClass> -->
           <excludes>
-            <exclude>**/IronpythonTest.java</exclude>
+            <!-- IronPython is .NET-only and cannot be provisioned on the Linux
+                 CI runner, so exclude all of its tests (not just IronpythonTest). -->
+            <exclude>**/Ironpython*Test.java</exclude>
             <exclude>**/Abstract*Test.java</exclude>
             <exclude>**/Abstract*TestCase.java</exclude>
             <exclude>**/*$*</exclude>


### PR DESCRIPTION
## What This Does

Revives the `Tests - PyDev` workflow, which had **no successful run in recorded history**. It failed at JDK setup before anything could build. This PR is scoped to the **infrastructure** needed to make CI build and run the test suite again. It is **not** an attempt at 100% green (see "Out of Scope").

### Infrastructure Fixes
- **Cache 400 and deprecated actions:** `actions/setup-java@v2`→`v4` (the v2 cache backend was retired and returned HTTP 400), plus `checkout@v2`→`v4` and `setup-python@v2`→`v5`.
- **Python 2.7:** `setup-python` dropped 2.7 in 2023, so install it from the Ubuntu 22.04 archive (runner pinned to 22.04), bootstrap legacy get-pip, and repoint the hardcoded `PYTHON2_*` paths.
- **Conda:** provision a named Python 3.8 conda env (base conda on PATH) for `InterpreterInfoTest.testObtainCondaEnv`.
- **JDK paths:** use `$JAVA_HOME` instead of a hardcoded JDK patch version.
- **Test excludes:** broaden the IronPython exclude and add Jython (both unprovisionable here, since Jython needs `rt.jar`, gone since Java 9), matching upstream.

### Minimal Product Changes
`AbstractShell.endIt()` and `ModulesManager.handleFileContents()` widened to `public` for cross-bundle (OSGi) test access. Both are already `public` in upstream `fabioz/Pydev`.

## Result
CI goes from **dead at JDK setup** to **building the full Tycho suite and running ~1100 tests**.

## Out of Scope
Fully-green CI requires migrating this 9.3-era branch's build to upstream's modern toolchain (Tycho 4.x, JDK 17, dropped py2/conda). That is a multi-plugin migration. A `tycho-source-feature-plugin` removal already breaks a naive Tycho 4 bump, and it is tracked as a separate, deliberate effort. A few tests still fail under the current Tycho 2.7.5 toolchain (e.g. `ModulesManagerTest` cross-bundle access, which upstream avoids via Tycho 4). These are the fork-vs-upstream toolchain gap, not regressions from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
